### PR TITLE
adds optional pagination params to WebhookLog#list

### DIFF
--- a/lib/fund_america/webhook_log.rb
+++ b/lib/fund_america/webhook_log.rb
@@ -5,10 +5,7 @@ module FundAmerica
       # End point: https://apps.fundamerica.com/api/webhook_logs (GET)
       # Usage: FundAmerica::WebhookLog.list
       # Output: Returns list of webhook_logs
-      def list(page: nil, per: nil)
-        err_msg = "Please use both parameters, page and per, if you use them."
-        fail ArgumentError, err_msg if (page && !per) || (!page && per)
-
+      def list(page: 1, per: 25)
         request_uri = FundAmerica.base_uri + 'webhook_logs'
         request_uri += "/?page=#{page}&per=#{per}" if page
         API::request(:get, request_uri)

--- a/lib/fund_america/webhook_log.rb
+++ b/lib/fund_america/webhook_log.rb
@@ -5,8 +5,13 @@ module FundAmerica
       # End point: https://apps.fundamerica.com/api/webhook_logs (GET)
       # Usage: FundAmerica::WebhookLog.list
       # Output: Returns list of webhook_logs
-      def list
-        API::request(:get, FundAmerica.base_uri + 'webhook_logs')
+      def list(page: nil, per: nil)
+        err_msg = "Please use both parameters, page and per, if you use them."
+        fail ArgumentError, err_msg if (page && !per) || (!page && per)
+
+        request_uri = FundAmerica.base_uri + 'webhook_logs'
+        request_uri += "/?page=#{page}&per=#{per}" if page
+        API::request(:get, request_uri)
       end
 
       # End point: https://apps.fundamerica.com/api/webhook_logs/:id (GET)

--- a/lib/fund_america/webhook_log.rb
+++ b/lib/fund_america/webhook_log.rb
@@ -2,9 +2,12 @@ module FundAmerica
   class WebhookLog
     class << self
 
-      # End point: https://apps.fundamerica.com/api/webhook_logs (GET)
+      # End point: https://apps.fundamerica.com/api/webhook_logs/?page=[num]&per=[num] (GET)
       # Usage: FundAmerica::WebhookLog.list
       # Output: Returns list of webhook_logs
+      # Params: (method defaults are the same as the current API defaults)
+      #  * page - page number of results; starts at 1, not 0
+      #  * per - number of results per page
       def list(page: 1, per: 25)
         request_uri = FundAmerica.base_uri + 'webhook_logs'
         request_uri += "/?page=#{page}&per=#{per}" if page

--- a/spec/fund_america/webhook_log_spec.rb
+++ b/spec/fund_america/webhook_log_spec.rb
@@ -52,6 +52,29 @@ describe FundAmerica::WebhookLog do
       expect(@response['resources']).to be_instance_of(Array)
     end
 
+    context 'using #list with pagination' do
+      let(:base_url) { "https://sandbox.fundamerica.com/api/webhook_logs" }
+      let(:base_url_with_params) { "https://sandbox.fundamerica.com/api/webhook_logs/?page=2&per=25" }
+
+      it "builds the correct URL with no parameters" do
+        expect(FundAmerica::API).to receive(:request).with(:get, base_url)
+        FundAmerica::WebhookLog.list
+      end
+
+      it "throws an exception if only `page` is used" do
+        expect { FundAmerica::WebhookLog.list(page: 2) }.to raise_error(ArgumentError)
+      end
+
+      it "throws an exception if only `per` is used" do
+        expect { FundAmerica::WebhookLog.list(per: 25) }.to raise_error(ArgumentError)
+      end
+
+      it "builds the correct URL with both parameters" do
+        expect(FundAmerica::API).to receive(:request).with(:get, base_url_with_params)
+        FundAmerica::WebhookLog.list(page: 2, per: 25)
+      end
+    end
+
     context '#details' do
       it 'must have object as webhook_log' do
         unless @webhook.nil?

--- a/spec/fund_america/webhook_log_spec.rb
+++ b/spec/fund_america/webhook_log_spec.rb
@@ -53,25 +53,17 @@ describe FundAmerica::WebhookLog do
     end
 
     context 'using #list with pagination' do
-      let(:base_url) { "https://sandbox.fundamerica.com/api/webhook_logs" }
-      let(:base_url_with_params) { "https://sandbox.fundamerica.com/api/webhook_logs/?page=2&per=25" }
+      let(:base_url_with_default_params) { "https://sandbox.fundamerica.com/api/webhook_logs/?page=1&per=25" }
+      let(:base_url_with_custom_params) { "https://sandbox.fundamerica.com/api/webhook_logs/?page=2&per=26" }
 
       it "builds the correct URL with no parameters" do
-        expect(FundAmerica::API).to receive(:request).with(:get, base_url)
+        expect(FundAmerica::API).to receive(:request).with(:get, base_url_with_default_params)
         FundAmerica::WebhookLog.list
       end
 
-      it "throws an exception if only `page` is used" do
-        expect { FundAmerica::WebhookLog.list(page: 2) }.to raise_error(ArgumentError)
-      end
-
-      it "throws an exception if only `per` is used" do
-        expect { FundAmerica::WebhookLog.list(per: 25) }.to raise_error(ArgumentError)
-      end
-
       it "builds the correct URL with both parameters" do
-        expect(FundAmerica::API).to receive(:request).with(:get, base_url_with_params)
-        FundAmerica::WebhookLog.list(page: 2, per: 25)
+        expect(FundAmerica::API).to receive(:request).with(:get, base_url_with_custom_params)
+        FundAmerica::WebhookLog.list(page: 2, per: 26)
       end
     end
 


### PR DESCRIPTION
It's odd that we include a "next_url" key (see below) and then offer
no way to request that URL, or its equivalent, through the FundAmerica gem
instead of using API::request directly.

Since page defaults to 1 and per defaults to 25, it looks like this gem lacks
any way to get details about WebhookLogs that are older than the 25 most recent.

(Perhaps this is a part of the gem that is still under construction, or no one
has needed to check more than 25 at a time, previously?)

Example output:

```
[1] pry(main)> FundAmerica::WebhookLog.list
=> {"object"=>"resource_list",
    "total_resources"=>40,
    "page"=>1,
    "per"=>25,
    "more"=>true,
    "next_url"=>"https://sandbox.fundamerica.com/api/webhook_logs?page=2&per=25",
    "resources"=>
      [{"object"=>"webhook_log",
      ...
```