### PR TITLE
the API should respond with JSON, when we request the wrong ID, but c…

### DIFF
--- a/lib/fund_america/api.rb
+++ b/lib/fund_america/api.rb
@@ -8,7 +8,7 @@ module FundAmerica
       def request method, uri, options={}
         options = FundAmerica.basic_auth.merge!({:body => options})
         response = HTTParty.send(method, uri, options)
-        parsed_response = JSON.parse(response.body)
+        parsed_response = parse_response_body(response.body)
         if response.code.to_i == 200
           # Returns parsed_response - a hash of response body
           # if response is successful
@@ -37,6 +37,18 @@ module FundAmerica
       # Usage: FundAmerica::API.ledger_entry(ledger_entry_id)
       def ledger_entry(ledger_entry_id)
         API::request(:get, FundAmerica.base_uri + "ledger_entries/#{ledger_entry_id}")
+      end
+
+      # Parses a JSON response
+      def parse_response_body(body)
+        parsed_response = JSON.parse(body)
+      rescue JSON::ParserError => _e
+        # Would like to do an error message like:
+        #   "Could not parse response body as JSON: #{body}"
+        # but this gem only uses pre-assigned error message codes, and
+        # the "else" message is least misleading about what went wrong.
+        # See: https://github.com/rubyeffect/fund_america/blob/5e6b5184d1e5ca4bb7ccf7c17dd9d174f5ec6210/lib/fund_america/error.rb#L12-L28
+        raise FundAmerica::Error.new(body, 999)
       end
     end
   end

--- a/lib/fund_america/api.rb
+++ b/lib/fund_america/api.rb
@@ -8,7 +8,7 @@ module FundAmerica
       def request method, uri, options={}
         options = FundAmerica.basic_auth.merge!({:body => options})
         response = HTTParty.send(method, uri, options)
-        parsed_response = parse_response_body(response.body)
+        parsed_response = parse_response_body(response.body, response.code.to_i)
         if response.code.to_i == 200
           # Returns parsed_response - a hash of response body
           # if response is successful
@@ -40,7 +40,7 @@ module FundAmerica
       end
 
       # Parses a JSON response
-      def parse_response_body(body)
+      def parse_response_body(body, response_code)
         parsed_response = JSON.parse(body)
       rescue JSON::ParserError => _e
         # Would like to do an error message like:
@@ -48,7 +48,7 @@ module FundAmerica
         # but this gem only uses pre-assigned error message codes, and
         # the "else" message is least misleading about what went wrong.
         # See: https://github.com/rubyeffect/fund_america/blob/5e6b5184d1e5ca4bb7ccf7c17dd9d174f5ec6210/lib/fund_america/error.rb#L12-L28
-        raise FundAmerica::Error.new(body, 999)
+        raise FundAmerica::Error.new(body, response_code)
       end
     end
   end

--- a/spec/fund_america/api_spec.rb
+++ b/spec/fund_america/api_spec.rb
@@ -6,4 +6,23 @@ describe FundAmerica::API do
       expect(FundAmerica::API.clear_data).not_to be nil
     end
   end
+
+  context '#parse_response_body' do
+    let(:body) { nil }
+    subject { FundAmerica::API.parse_response_body(body) }
+
+    context 'sent a response.body of JSON' do
+      let(:body) { '{"foo": "bar"}' }
+      it 'parses the JSON without error' do
+        expect(subject).to eq({'foo' => 'bar'})
+      end
+    end
+
+    context 'sent a response.body of HTML' do
+      let(:body) { '<!DOCTYPE html><html><head></head><body>Oops we sent HTML</body></html>' }
+      it 'throws an expected error' do
+        expect { subject }.to raise_error(FundAmerica::Error)
+      end
+    end
+  end
 end

--- a/spec/fund_america/api_spec.rb
+++ b/spec/fund_america/api_spec.rb
@@ -9,12 +9,12 @@ describe FundAmerica::API do
 
   context '#parse_response_body' do
     let(:body) { nil }
-    subject { FundAmerica::API.parse_response_body(body) }
+    subject { FundAmerica::API.parse_response_body(body, 404) }
 
     context 'sent a response.body of JSON' do
-      let(:body) { '{"foo": "bar"}' }
+      let(:body) { '{"message": "Could not find an entity with that ID"}' }
       it 'parses the JSON without error' do
-        expect(subject).to eq({'foo' => 'bar'})
+        expect(subject).to eq({'message' => 'Could not find an entity with that ID'})
       end
     end
 


### PR DESCRIPTION
…urrently serves HTML

Note: FundAmerica tech support replied:

"I’m going to have to look into why this is happening. You should actually get JSON back with a status code and a message. I’ll update you later today on the matter."

But I haven't heard back yet, and it could happen again.

*Note:* `Gemfile.lock` should be updated in our `playfig` project, when this is merged, so it has the correct hash. And then I need to update this bit of error handling, too: https://github.com/playfig/website/blob/62efcbe2b19e5fc568120680f908c528ed28fd12/app/models/fundamerica_callback.rb#L69-L74